### PR TITLE
Fix mangling of line endings and duplicate rake in gemspec

### DIFF
--- a/cuke_cataloger.gemspec
+++ b/cuke_cataloger.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rake'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'cucumber'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'racatt'

--- a/lib/cuke_cataloger/unique_test_case_tagger.rb
+++ b/lib/cuke_cataloger/unique_test_case_tagger.rb
@@ -312,7 +312,7 @@ module CukeCataloger
       file_lines = File.readlines(file_path)
       file_lines.insert(tag_index, "#{padding_string}#{tag}\n")
 
-      File.open(file_path, 'w') { |file| file.print file_lines.join }
+      File.open(file_path, 'wb') { |file| file.print file_lines.join }
       @file_line_increases[file_path] += 1
       test.tags << tag
     end
@@ -330,7 +330,7 @@ module CukeCataloger
 
           new_parameter = 'test_case_id'.ljust(parameter_spacing(example))
           update_parameter_row(file_lines, parameter_line_index, new_parameter)
-          File.open(file_path, 'w') { |file| file.print file_lines.join }
+          File.open(file_path, 'wb') { |file| file.print file_lines.join }
         end
       end
     end
@@ -356,7 +356,7 @@ module CukeCataloger
           end
         end
 
-        File.open(file_path, 'w') { |file| file.print file_lines.join }
+        File.open(file_path, 'wb') { |file| file.print file_lines.join }
       end
     end
 


### PR DESCRIPTION
This PR uses binary mode for writing the features files out so that line endings to not get mangled.  Without this change each time you run tag_tests every feature file will show as modified and needing a commit if the line endings differ from the what the OS tag_tests is run under.

This also removes the duplicated dependency on rake in the gemspec.  Newer versions of bundler refuse to bundle the gemspec without this change
